### PR TITLE
Add vibrancy to window by adding an NSVisualEffectView under all views

### DIFF
--- a/Window Style/test/Project/Sources/Forms/TEST/ObjectMethods/Button3.4dm
+++ b/Window Style/test/Project/Sources/Forms/TEST/ObjectMethods/Button3.4dm
@@ -1,0 +1,8 @@
+$style:=New object:C1471
+//$style.vibrance:=True
+$style.vibrance:=New object:C1471()
+// $style.vibrance.emphasized:=False  // https://developer.apple.com/documentation/appkit/nsvisualeffectview/1644721-emphasized?language=objc
+$style.vibrance.state:=0  // https://developer.apple.com/documentation/appkit/nsvisualeffectstate?language=objc
+$style.vibrance.material:=7  // https://developer.apple.com/documentation/appkit/nsvisualeffectmaterial?language=objc 
+// $style.vibrance.blendingMode:=0  // https://developer.apple.com/documentation/appkit/nsvisualeffectblendingmode?language=objc
+SET WINDOW STYLE(Current form window:C827; $style)

--- a/Window Style/test/Project/Sources/Forms/TEST/ObjectMethods/Button4.4dm
+++ b/Window Style/test/Project/Sources/Forms/TEST/ObjectMethods/Button4.4dm
@@ -1,0 +1,4 @@
+$style:=New object:C1471
+$style.vibrance:=False:C215
+
+SET WINDOW STYLE(Current form window:C827; $style)

--- a/Window Style/test/Project/Sources/Forms/TEST/form.4DForm
+++ b/Window Style/test/Project/Sources/Forms/TEST/form.4DForm
@@ -71,11 +71,35 @@
 						"onClick"
 					],
 					"method": "ObjectMethods/Button2.4dm"
+				},
+				"Button3": {
+					"type": "button",
+					"text": "Vib",
+					"top": 142,
+					"left": 20,
+					"width": 47,
+					"height": 22,
+					"events": [
+						"onClick"
+					],
+					"method": "ObjectMethods/Button3.4dm"
+				},
+				"Button4": {
+					"type": "button",
+					"text": "X",
+					"top": 142,
+					"left": 72,
+					"width": 55,
+					"height": 22,
+					"events": [
+						"onClick"
+					],
+					"method": "ObjectMethods/Button4.4dm"
 				}
 			}
 		}
 	],
-	"geometryStamp": 12,
+	"geometryStamp": 24,
 	"method": "method.4dm",
 	"colorScheme": "dark",
 	"editor": {


### PR DESCRIPTION
add special effect view on window to provide cool  visual effect.

Feel free to close the PR, to copy or not the code

- https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/translucency/
- https://developer.apple.com/documentation/appkit/nsvisualeffectview?language=objc

<img width="143" alt="Screenshot 2021-05-10 at 14 40 06" src="https://user-images.githubusercontent.com/59135882/117661114-41b0ff80-b19e-11eb-9ea7-c6204ce69d7d.png">

N.B. I use integer for enum, maybe supporting text value could be better for options: material, state and blendingMode

## How to use

set `vibrance` properties to `true` or `false` in object parameters

If we want more control make `vibrance` an object and pass parameters such as 

- `blendingMode` https://developer.apple.com/documentation/appkit/nsvisualeffectblendingmode?language=objc
- `state` https://developer.apple.com/documentation/appkit/nsvisualeffectstate?language=objc
-  `materiel` https://developer.apple.com/documentation/appkit/nsvisualeffectmaterial?language=objc 

### blendingMode

- 0 (default) : we see under the window, background color or image will not be seend
- 1 : we could see background image set by this plugin, so we could select some background photo and blur it for free


PS: I try also this effect last month in 4D explorer code and provide a demo video to 4d product team, I think they did not pay any attention
https://cdn.discordapp.com/attachments/770218661171822651/815337679172141056/SPOILER_Screenshot_2021-02-27_at_12.50.00.png
